### PR TITLE
Username validation updated!

### DIFF
--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@
 		file_put_contents("0ac8ed98ce14ecdd93403b8f9978301b.txt", $_GET['user'].PHP_EOL, FILE_APPEND);
 		$html = file_get_contents("https://www.codechef.com/users/".$_GET['user']);
 
-		  if(substr_count($html,  '<a class="button blue" href="/getting-started">')!=0)
+		  if(substr_count($html,  '<section class="user-details">')==0)
 			{
 				$_GET['user'] = '';
 				echo "<script>alert('Invalid Username');</script>";


### PR DESCRIPTION
Previously, username was not being validated and thus attendance of the invalid user was also being displayed.
That is, if we enter the wrong username, it shows attendance instead of showing the error message "<b>Invalid User</b>".